### PR TITLE
feat: Remove endorsements from the proposal page

### DIFF
--- a/app/views/decidim/proposals/proposals/show.html.erb
+++ b/app/views/decidim/proposals/proposals/show.html.erb
@@ -1,0 +1,141 @@
+<%
+  add_decidim_meta_tags({
+    description: present(@proposal).body,
+    title: present(@proposal).title,
+    url: proposal_url(@proposal.id)
+  })
+%>
+
+<%
+  edit_link(
+    resource_locator(@proposal).edit,
+    :edit,
+    :proposal,
+    proposal: @proposal
+  )
+%>
+
+<%
+  extra_admin_link(
+    resource_locator(@proposal).show(anchor: "proposal-answer"),
+    :create,
+    :proposal_answer,
+    { proposal: @proposal },
+    { name: t(".answer"), icon: "comment-square" }
+  )
+%>
+
+<%= render partial: "voting_rules" %>
+<% if component_settings.participatory_texts_enabled? %>
+  <div class="row column">
+    <div class="section text-medium">
+      <%= t(".back_to") %> <u><%= link_to translated_attribute(@participatory_text.title), main_component_path(current_component) %></u>
+    </div>
+  </div>
+<% end %>
+<%= emendation_announcement_for @proposal %>
+<div class="row column view-header">
+
+  <div class="m-bottom">
+    <%= link_to proposals_path, class: "small hollow js-back-to-list" do %>
+      <%= icon "chevron-left", class: "icon--small", role: "img", "aria-hidden": true %>
+      <%= t(".back_to_list") %>
+    <% end %>
+  </div>
+
+  <% if @proposal.emendation? %>
+    <h2 class="heading3"><%= t(".changes_at_title", title: present(@proposal.amendable).title(links: true, html_escape: true)) %></h2>
+  <% else %>
+    <h2 class="heading3"><%= present(@proposal).title(links: true, html_escape: true) %></h2>
+  <% end %>
+  <% unless component_settings.participatory_texts_enabled? %>
+    <%= cell("decidim/coauthorships", @proposal, has_actions: true, size: 3, context: { current_user: current_user }) %>
+  <% end %>
+</div>
+<div class="row">
+  <div class="columns mediumlarge-8 large-9">
+    <div class="section">
+      <% if @proposal.emendation? %>
+        <%= cell("decidim/diff", proposal_presenter.versions.last) %>
+      <% elsif not ["section","subsection"].include? @proposal.participatory_text_level %>
+        <%== cell("decidim/proposals/proposal_m", @proposal, full_badge: true).badge %>
+        <%= render_proposal_body(@proposal) %>
+      <% end %>
+      <% if component_settings.geocoding_enabled? %>
+        <%= render partial: "decidim/shared/static_map", locals: { icon_name: "proposals", geolocalizable: @proposal } %>
+      <% end %>
+      <% if proposal_has_costs? && current_settings.answers_with_costs? %>
+        <%= cell("decidim/proposals/cost_report", @proposal) %>
+      <% end %>
+    </div>
+
+    <%= cell("decidim/announcement", proposal_reason_callout_announcement, callout_class: proposal_reason_callout_class) if @proposal.answered? && @proposal.published_state? %>
+
+    <%= linked_resources_for @proposal, :results, "included_proposals" %>
+    <%= linked_resources_for @proposal, :projects, "included_proposals" %>
+    <%= linked_resources_for @proposal, :meetings, "proposals_from_meeting" %>
+    <%= linked_resources_for @proposal, :proposals, "copied_from_component" %>
+
+    <%= amendments_for @proposal %>
+  </div>
+  <div class="columns section view-side mediumlarge-4 large-3">
+    <% if @proposal.amendable? && allowed_to?(:edit, :proposal, proposal: @proposal) %>
+      <%= link_to t(".edit_proposal"), edit_proposal_path(@proposal), class: "button hollow expanded button--sc" %>
+    <% else %>
+      <%= amend_button_for @proposal %>
+    <% end %>
+
+    <%= emendation_actions_for @proposal %>
+
+    <% if current_settings.votes_enabled? || show_endorsements_card? || current_user %>
+      <% if @proposal.withdrawn? %>
+        <div class="card">
+          <div class="card__content">
+            <% if current_settings.votes_enabled? %>
+              <%= render partial: "votes_count", locals: { proposal: @proposal, from_proposals_list: false } %>
+            <% end %>
+          </div>
+        </div>
+      <% else %>
+        <div class="card">
+          <div class="card__content">
+            <% if current_settings.votes_enabled? %>
+              <%= render partial: "votes_count", locals: { proposal: @proposal, from_proposals_list: false } %>
+              <%= render partial: "vote_button", locals: { proposal: @proposal, from_proposals_list: false } %>
+            <% end %>
+            <div class="row collapse buttons__row">
+              <% if endorsements_enabled? %>
+                <div class="column small-9 collapse">
+                  <%= endorsement_buttons_cell(@proposal) %>
+                </div>
+              <% end %>
+              <div class="column collapse <%= endorsements_enabled? ? "small-3" : "" %>">
+                <%= link_to "#comments", class: "button small compact hollow secondary button--nomargin expanded" do %>
+                  <span class="show-for-sr"><%= present(@proposal).title(html_escape: true) %></span>
+                  <%= icon "comment-square", class: "icon--small", aria_label: t(".comments"), role: "img" %> <%= @proposal.comments_count %>
+                <% end %>
+              </div>
+            </div>
+            <br>
+            <%= follow_button_for(@proposal) %>
+          </div>
+        </div>
+      <% end %>
+    <% end %>
+
+    <%= amenders_list_for(@proposal) %>
+
+    <%= resource_reference(@proposal) %>
+    <%= resource_version(proposal_presenter, versions_path: proposal_versions_path(@proposal)) %>
+    <%= cell("decidim/fingerprint", @proposal) %>
+    <%= render partial: "decidim/shared/share_modal", locals: { resource: @proposal } %>
+    <%= embed_modal_for proposal_widget_url(@proposal, format: :js) %>
+    <%= cell "decidim/proposals/proposal_link_to_collaborative_draft", @proposal %>
+    <%= cell "decidim/proposals/proposal_link_to_rejected_emendation", @proposal %>
+  </div>
+</div>
+<%= attachments_for @proposal %>
+
+<%= comments_for @proposal %>
+
+<%= cell("decidim/flag_modal", @proposal) %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -54,6 +54,15 @@ en:
           email_outro: You have received this notification because you are participating in "%{participatory_space_title}"
           email_subject: Your vote is still pending in %{participatory_space_title}
           notification_title: The vote on budget <a href="%{resource_path}">%{resource_title}</a> is still waiting for your confirmation in %{participatory_space_title}
+    proposals:
+      proposals:
+        show:
+          answer: Answer
+          back_to: Back to
+          back_to_list: Back to the list
+          changes_at_title: Changes at (%{title}")
+          comments: Comments
+          edit_proposal: Edit proposal
     verifications:
       authorizations:
         first_login:

--- a/config/locales/fr.yml
+++ b/config/locales/fr.yml
@@ -54,6 +54,15 @@ fr:
           email_outro: Vous avez reçu cette notification parce que vous avez commencé à voter sur la concertation "%{participatory_space_title}"
           email_subject: Votre vote est toujours en attente sur la concertation %{participatory_space_title}
           notification_title: Votre vote pour le budget <a href="%{resource_path}">%{resource_title}</a> attend d'être finalisé sur la concertation %{participatory_space_title}
+    proposals:
+      proposals:
+        show:
+          answer: Répondre
+          back_to: Retour à
+          back_to_list: Retour à la liste
+          changes_at_title: Amendement de (%{title}")
+          comments: Commentaires
+          edit_proposal: Modifier la proposition
     shared:
       login_modal:
         close_modal: Fermer


### PR DESCRIPTION
#### :tophat: Description
*Please describe your pull request.*

This PR removes the endorsements from a proposal page which could cause some problems when there was a lot of endorsements for a single proposal

#### :pushpin: Related Issues

- [Notion card](https://www.notion.so/opensourcepolitics/Cour-des-comptes-Enlever-la-liste-des-soutiens-des-propositions-aba5bb6947ae4894bb25fbc5f1e58173?pvs=4)

#### Testing
*Describe the best way to test or validate your PR.*

Example:
* Log in as user
* Access a process
* Access to proposals
* Check a proposal that has endorsements
* Make sure that you don't have the list of endorsements when accessing to the page of the proposal

#### Tasks
- [x] Override the file to remove the endorsement list
- [x] Add missing locales 

### :camera: Screenshots
*Please add screenshots of the changes you're proposing if related to the UI*
